### PR TITLE
fix: change macOS launchd plist to use StartInterval and RunAtLoad

### DIFF
--- a/focus_time_app/cli/background_scheduler/impl/macos_background_scheduler.py
+++ b/focus_time_app/cli/background_scheduler/impl/macos_background_scheduler.py
@@ -16,8 +16,8 @@ class MacOsBackgroundScheduler(AbstractBackgroundScheduler):
 
     LAUNCHD_AGENT_DICT = {
         "Label": f"com.focustime{get_environment_suffix()}",
-        "KeepAlive": True,
-        "ThrottleInterval": 60  # seconds
+        "StartInterval": 60,  # seconds
+        "RunAtLoad": True
     }
     LAUNCHD_AGENT_FILE = Path.home() / "Library" / "LaunchAgents" / f"com.focustime{get_environment_suffix()}.plist"
 


### PR DESCRIPTION
This should improve the stability of the background jobs. Previously, KeepAlive and ThrottleInterval was used, which caused the background job to be suspended after about one day