### PR TITLE
Revert "Feature: remove pytz usage due to updated O365 lib release"

### DIFF
--- a/focus_time_app/focus_time_calendar/impl/outlook365_calendar_adapter.py
+++ b/focus_time_app/focus_time_calendar/impl/outlook365_calendar_adapter.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import List, Optional, Dict, Any, Tuple
 
 import marshmallow_dataclass
+import pytz
 import typer
 from O365 import Account
 from O365.calendar import Schedule, Calendar, Event
@@ -60,8 +61,11 @@ class Outlook365CalendarAdapter(AbstractCalendarAdapter):
     def check_connection_and_credentials(self):
         if not self._outlook_configuration:
             raise ValueError("Cannot check connection, Outlook configuration is missing")
+        # Note: we set the "timezone=pytz.UTC" argument only to avoid PytzUsageWarning that point to
+        # https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
+        # The issue is known (https://github.com/O365/python-o365/issues/753) but unlikely to be fixed soon
         self._account = Account(str(self._outlook_configuration.client_id), auth_flow_type="public",
-                                token_backend=self._backend,
+                                token_backend=self._backend, timezone=pytz.UTC,
                                 tenant_id=self._outlook_configuration.tenant_id or OUTLOOK365_OAUTH_COMMON_TENANT)
         if not self._account.is_authenticated:
             raise RuntimeError("Unable to load auth token")


### PR DESCRIPTION
Reverts focus-time/focus-time-app#58

Rationale: the error message (`PytzUsageWarning: The zone attribute is specific to pytz's interface ...`) still appears.