### PR TITLE
fix: use shell=True in various subprocess.check_call/check_output calls

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -39,10 +39,13 @@ jobs:
 
       - name: Run integration tests
         if: startsWith(github.ref, 'refs/tags/') == false
-        uses: nick-fields/retry@v2  # tests are a bit flaky and time out after 6h, so we auto-retry them
+        uses: nick-fields/retry@v2  # tests are a bit flaky and time out after 6h, so we auto-retry them and reduce the timeout
         with:
           timeout_minutes: 60
           max_attempts: 2
+          # Note: should the test suite hang (without any output), put "-o faulthandler_timeout=240" right after "pytest"
+          # which dumps the traceback of all threads after a timeout or segfault,
+          # see https://docs.pytest.org/en/7.1.x/how-to/failures.html#fault-handler
           command: |
             playwright install --with-deps chromium
             pytest tests --junitxml=junit/test-results.xml

--- a/focus_time_app/command_execution/impl/macos_command_executor.py
+++ b/focus_time_app/command_execution/impl/macos_command_executor.py
@@ -37,7 +37,7 @@ class MacOsCommandExecutor(AbstractCommandExecutor):
                               shell=True)
 
     def is_dnd_helper_installed(self) -> bool:
-        output_bytes = subprocess.check_output(["/usr/bin/shortcuts", "list"])
+        output_bytes = subprocess.check_output(["/usr/bin/shortcuts", "list"], shell=True)
         output_lines = output_bytes.decode("utf-8").splitlines()
         return CommandExecutorConstants.MACOS_FOCUS_MODE_SHORTCUT_NAME in output_lines
 
@@ -54,7 +54,7 @@ class MacOsCommandExecutor(AbstractCommandExecutor):
         else:
             path = str(Path(__file__).parent.parent.parent.parent / "resources"
                        / f"{CommandExecutorConstants.MACOS_FOCUS_MODE_SHORTCUT_NAME}.shortcut")
-        subprocess.check_call(["open", path])
+        subprocess.check_call(["open", path], shell=True)
         typer.prompt("Press Enter once you have installed the shortcut.", default='', prompt_suffix='\n')
 
     def uninstall_dnd_helpers(self):

--- a/macos-installer.py
+++ b/macos-installer.py
@@ -105,7 +105,7 @@ def install_or_upgrade_app(temp_archive_path: Path, installation_path: Path, is_
                   "causes a macOS dialog to show up, asking you to grant 'focus-time' access to the keychain again. "
                   "You have to provide your password and then click 'Always allow'.")
 
-            output = subprocess.check_output([str(focus_time_binary_path), "sync"]).decode("utf-8")
+            output = subprocess.check_output([str(focus_time_binary_path), "sync"], shell=True).decode("utf-8")
             print(f"Result of 'sync' command: {output}")
         # Install the background job again
         subprocess.call([str(focus_time_binary_path), "doctor"])


### PR DESCRIPTION
This fixes the hanging CI test suite on macOS